### PR TITLE
Initializing the Next.js project

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "workspace-test",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,7 @@
+import { AppProps } from 'next/app';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,4 @@
-import { AppProps } from 'next/app';
-
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />;
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Home = () => {
+  return (
+    <div>
+      <h1>Welcome to Next.js!</h1>
+    </div>
+  );
+};
+
+export default Home;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,17 @@
+/* Global Styles */
+
+body {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: inherit;
+}


### PR DESCRIPTION
Related to #1

Initialize the Next.js project with a basic architecture and folder structure.

* Add `pages/index.js` with a default Next.js home page component.
* Add `pages/_app.js` with a custom App component.
* Add `styles/globals.css` with basic global styles.
* Add `package.json` with default Next.js settings, dependencies, and scripts.
* Add `next.config.js` with an empty object.
* Create the `public` directory.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/outsideris/workspace-test/issues/1?shareId=d8f5772f-1f78-43f4-baad-b285dbdf6f56).